### PR TITLE
Use micro as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -437,11 +437,6 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
-    "bytes": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
-      "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
-    },
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -670,11 +665,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "depd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -1110,17 +1100,6 @@
         "whatwg-encoding": "1.0.1"
       }
     },
-    "http-errors": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
-      "requires": {
-        "depd": "1.1.0",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
-      }
-    },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
@@ -1151,7 +1130,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "invariant": {
       "version": "2.2.2",
@@ -1909,26 +1889,11 @@
         "tmpl": "1.0.4"
       }
     },
-    "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
     "merge": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true
-    },
-    "micro": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/micro/-/micro-8.0.3.tgz",
-      "integrity": "sha512-ntTKZT6wtQKAAafZ8uGaRzM3hC2MZ+tHoc20aik7qzKa7cmCDi4TuTclBUDSnhesWZgo0W0qqDHR6fUQ2EJhbQ==",
-      "requires": {
-        "media-typer": "0.3.0",
-        "mri": "1.1.0",
-        "raw-body": "2.3.0"
-      }
     },
     "micromatch": {
       "version": "2.3.11",
@@ -1989,11 +1954,6 @@
       "requires": {
         "minimist": "0.0.8"
       }
-    },
-    "mri": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.0.tgz",
-      "integrity": "sha1-XAo/KcjM/7ux7JQdzsCdcfoy82o="
     },
     "ms": {
       "version": "2.0.0",
@@ -2367,24 +2327,6 @@
         "uuid": "3.0.0"
       }
     },
-    "raw-body": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.0.tgz",
-      "integrity": "sha1-95zhrKyrpbY2LTNFTXhdcSn0vGc=",
-      "requires": {
-        "bytes": "2.5.0",
-        "http-errors": "1.6.1",
-        "iconv-lite": "0.4.18",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-          "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
-        }
-      }
-    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -2605,11 +2547,6 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "setprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -2701,11 +2638,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
       "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
-    },
-    "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
     "string-length": {
       "version": "1.0.1",
@@ -2884,11 +2816,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "uuid": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
   "license": "MIT",
   "dependencies": {
     "boom": "^5.2.0",
-    "micro": "^8.0.3",
     "raven": "^2.1.2"
   },
   "devDependencies": {
     "isomorphic-fetch": "^2.2.1",
     "jest": "^20.0.4",
     "test-listen": "^1.0.2"
+  },
+  "peerDependencies": {
+    "micro": "^9.0.2"
   }
 }


### PR DESCRIPTION
If you are using micro 9, using this module installs micro 8. Keeping them in sync is not a great idea, they should really be a peer dependency IMO. What do you think?