### PR TITLE
Log errors to stderr before sending them to sentry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ module.exports = exports = url => fn => {
     try {
       return await fn(request, response);
     } catch (error) {
+      console.error(error);
       Raven.captureException(error);
       let status = response.statusCode;
       if (status < 400) status = 500;


### PR DESCRIPTION
Hello!

We're using micro-sentry in production, and have noticed that it's preventing errors from being logged to stderr at all. This is really bad for us because we often exceed sentry's ratelimits, meaning those errors are completely lost as they're not visible in our logs or in sentry. This would also be the case if we were suffering networking issues and sentry was unreachable.

For now I've written a wrapper function to catch, log, and re-throw errors before micro-sentry does its thing, but it seems the best place for the logging is in micro-sentry itself.

Thanks